### PR TITLE
Wip/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
   - "4.0"
 install:
 - npm install elm@0.15.1-beta5
-- npm install elm-test
+- npm install elm-test@0.6.4
 - elm-package install -y
 script:
 - bin/fetch-configlet

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,10 @@ node_js:
   - "4.0"
 install:
 - npm install elm
+- npm install elm-test
 - node -v
-- curl  https://raw.githubusercontent.com/avh4/elm-spec/master/elm-io.sh > elm-io.sh
-- npm install jsdom
 - elm-package install -y
-before_script:
-- elm-make --yes --output raw-test.js TestRunner.elm
-- bash elm-io.sh raw-test.js test.js
 script:
 - bin/fetch-configlet
 - bin/configlet .
-- node test.js
+- node_modules/.bin/elm-test TestRunner.elm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "4.0"
 install:
-- npm install elm
+- npm install elm@0.15.1-beta5
 - npm install elm-test
 - elm-package install -y
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
 install:
 - npm install elm
 - npm install elm-test
-- node -v
 - elm-package install -y
 script:
 - bin/fetch-configlet

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 script:
 - bin/fetch-configlet
 - bin/configlet .
-- node_modules/.bin/elm-test TestRunner.elm
+- bin/ci-run-tests.sh

--- a/Accumulate/Accumulate.elm
+++ b/Accumulate/Accumulate.elm
@@ -1,0 +1,5 @@
+module Accumulate where
+
+accumulate : (a -> b) -> List a -> List b
+accumulate func input = 
+  []

--- a/Accumulate/AccumulateTest.elm
+++ b/Accumulate/AccumulateTest.elm
@@ -20,4 +20,4 @@ tests = suite "Accumulate"
           test "reverse Accumulate" (assertEqual ["olleh","dlrow"] (accumulate String.reverse ["hello" , "world"]))
         ]
 
-main = runDisplay tests
+-- main = runDisplay tests

--- a/Accumulate/AccumulateTest.elm
+++ b/Accumulate/AccumulateTest.elm
@@ -1,13 +1,12 @@
 module AccumulateTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import AccumulateExample exposing (accumulate)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 import String
+
+-- import AccumulateExample exposing (accumulate) -- CI_ENABLE
+import Accumulate exposing (accumulate) -- CI_DISABLE
 
 square : Int -> Int
 square x = x * x
@@ -20,4 +19,4 @@ tests = suite "Accumulate"
           test "reverse Accumulate" (assertEqual ["olleh","dlrow"] (accumulate String.reverse ["hello" , "world"]))
         ]
 
--- main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Anagram/Anagram.elm
+++ b/Anagram/Anagram.elm
@@ -1,0 +1,24 @@
+module Anagram where
+
+import List
+import String
+
+anagramsFor : String -> List String -> List String
+anagramsFor word candidates = 
+  []
+
+isAnagram : String -> String -> Bool
+isAnagram word1 word2 =
+  False
+
+alphabetizeWord : String -> List Char
+alphabetizeWord word =
+  []
+
+sameWord : String -> String -> Bool
+sameWord word1 word2 =
+  False
+
+sameLetters : String -> String -> Bool
+sameLetters word1 word2 =
+  False

--- a/Anagram/AnagramTest.elm
+++ b/Anagram/AnagramTest.elm
@@ -1,12 +1,11 @@
 module AnagramTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import AnagramExample exposing (anagramsFor)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
+
+-- import AnagramExample exposing (anagramsFor) -- CI_ENABLE
+import Anagram exposing (anagramsFor) -- CI_DISABLE
 
 tests : Test
 tests = suite "Anagram test suite"
@@ -25,4 +24,4 @@ tests = suite "Anagram test suite"
         test "does not detect a word as its own anagram (case insensitive)" (assertEqual  [] (anagramsFor "Banana" ["baNana"]))
         ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Bob/Bob.elm
+++ b/Bob/Bob.elm
@@ -1,0 +1,23 @@
+module Bob where
+
+import String exposing (..)
+
+responseFor : String -> String
+responseFor statement =
+  ""
+
+getWords : String -> String
+getWords statement =
+  ""
+
+isLetter : Char -> Bool
+isLetter letter =
+  False
+
+isShout : String -> Bool
+isShout statement =
+  False
+
+hasWords : String -> Bool
+hasWords statement =
+  False

--- a/Bob/BobTest.elm
+++ b/Bob/BobTest.elm
@@ -1,12 +1,11 @@
 module BobTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import BobExample exposing (responseFor)
+-- import BobExample exposing (responseFor) -- CI_ENABLE
+import Bob exposing (responseFor) -- CI_DISABLE
 
 tests : Test
 tests = suite "Bob Test Suite"
@@ -32,4 +31,4 @@ tests = suite "Bob Test Suite"
 
   ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/GradeSchool/GradeSchool.elm
+++ b/GradeSchool/GradeSchool.elm
@@ -1,0 +1,28 @@
+module GradeSchool where
+
+import Dict exposing (..)
+import Result exposing (toMaybe)
+
+schoolFromList : List (Int, String) -> Dict Int (List String)
+schoolFromList schoolList =
+  Dict.empty
+
+schoolToList : Dict Int (List String) -> List (Int, List String)
+schoolToList school = 
+  []
+
+newSchool : Dict Int (List String)
+newSchool = 
+  Dict.empty
+
+addStudent : Int -> String -> Dict Int (List String) -> Dict Int (List String)
+addStudent grade student school =
+  Dict.empty
+
+gradeWithStudents : Int -> List String -> Dict Int (List String)
+gradeWithStudents grade students =
+  Dict.empty
+
+studentsInGrade : Int -> Dict Int (List String) -> List String
+studentsInGrade grade school =
+  []

--- a/GradeSchool/GradeSchoolTest.elm
+++ b/GradeSchool/GradeSchoolTest.elm
@@ -6,13 +6,14 @@ module GradeSchoolTest where
 --   newSchool, gradeWithStudents, schoolFromList,
 --   studentsInGrade, schoolToList)
 
-import GradeSchoolExample as S exposing (..)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
 import Dict
+
+-- import GradeSchoolExample as S exposing (..) -- CI_ENABLE
+import GradeSchool as S exposing (..) -- CI_DISABLE
 
 tests : Test
 tests = suite "GradeSchool Test Suite"
@@ -28,4 +29,4 @@ tests = suite "GradeSchool Test Suite"
         test "get students in a non-existent grade" (assertEqual [] (S.studentsInGrade 1 S.newSchool))
         ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Leap/Leap.elm
+++ b/Leap/Leap.elm
@@ -1,0 +1,7 @@
+module Leap where
+
+import Debug
+
+isLeap : Int -> Bool
+isLeap year =
+  True

--- a/Leap/LeapTest.elm
+++ b/Leap/LeapTest.elm
@@ -1,12 +1,11 @@
 module LeapTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import LeapExample exposing (isLeap)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
+
+-- import LeapExample exposing (isLeap) -- CI_ENABLE
+import Leap exposing (isLeap) -- CI_DISABLE
 
 tests : Test
 tests = suite "Leap Test Suite"
@@ -17,4 +16,4 @@ tests = suite "Leap Test Suite"
           test "Yes, 2400 is a leap year" (assert (isLeap 2400))
         ]
 
--- main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Leap/LeapTest.elm
+++ b/Leap/LeapTest.elm
@@ -17,4 +17,4 @@ tests = suite "Leap Test Suite"
           test "Yes, 2400 is a leap year" (assert (isLeap 2400))
         ]
 
-main = runDisplay tests
+-- main = runDisplay tests

--- a/NucleotideCount/NucleotideCount.elm
+++ b/NucleotideCount/NucleotideCount.elm
@@ -1,0 +1,12 @@
+module NucleotideCount where
+
+import String
+import List
+
+nucleotideCounts : String -> List (Char, Int)
+nucleotideCounts sequence =
+  []
+
+getCount : Char -> String -> (Char, Int)
+getCount base sequence = 
+  ('', 0)

--- a/NucleotideCount/NucleotideCountTest.elm
+++ b/NucleotideCount/NucleotideCountTest.elm
@@ -1,12 +1,11 @@
 module NucleotideCountTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import NucleotideCountExample exposing (nucleotideCounts)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
+
+-- import NucleotideCountExample exposing (nucleotideCounts) -- CI_ENABLE
+import NucleotideCount exposing (nucleotideCounts) -- CI_DISABLE
 
 tests : Test
 tests = suite "NucleotideCount test suite"
@@ -19,4 +18,4 @@ tests = suite "NucleotideCount test suite"
                       (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"))
       ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/PhoneNumber/PhoneNumber.elm
+++ b/PhoneNumber/PhoneNumber.elm
@@ -1,0 +1,24 @@
+module PhoneNumber where
+
+import String
+
+nums = ['1','2','3','4','5','6','7','8','9','0']
+
+getNumber : String -> String
+getNumber text = getValidNum (String.filter isDigit text)
+
+isDigit : Char -> Bool
+isDigit char = List.any (\n -> n == char) nums
+
+getValidNum : String -> String
+getValidNum num =
+  if String.length num == 10 then num else
+    if (String.length num == 11) && (String.left 1 num == "1") then String.dropLeft 1 num else
+      String.repeat 10 "0"
+
+printPretty : String -> String
+printPretty input = formatNumber (getNumber input)
+
+
+formatNumber : String -> String
+formatNumber input = String.concat ["(", (String.slice 0 3 input),  ") ", (String.slice 3 6 input), "-", (String.slice 6 10 input)]

--- a/PhoneNumber/PhoneNumberTest.elm
+++ b/PhoneNumber/PhoneNumberTest.elm
@@ -1,12 +1,11 @@
 module PhoneNumberTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import PhoneNumberExample exposing (getNumber, printPretty)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
+
+-- import PhoneNumberExample exposing (getNumber, printPretty) -- CI_ENABLE
+import PhoneNumber exposing (getNumber, printPretty) -- CI_DISABLE
 
 tests : Test
 tests = suite "PhoneNumber test suite"
@@ -25,4 +24,4 @@ tests = suite "PhoneNumber test suite"
         test "pretty print with full us phone number" (assertEqual "(123) 456-7890" (printPretty "11234567890"))
       ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/PointMutations/PointMutations.elm
+++ b/PointMutations/PointMutations.elm
@@ -1,0 +1,11 @@
+module PointMutations where
+import String
+import List
+
+hammingDistance : String -> String -> Int
+hammingDistance firstString secondString =
+  0
+
+getComparedList : String -> String -> List Bool
+getComparedList firstString secondString =
+  []

--- a/PointMutations/PointMutationsTest.elm
+++ b/PointMutations/PointMutationsTest.elm
@@ -1,12 +1,11 @@
 module PointMutationsTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import PointMutationsExample exposing (hammingDistance)
+-- import PointMutationsExample exposing (hammingDistance) -- CI_ENABLE
+import PointMutations exposing (hammingDistance) -- CI_DISABLE
 
 import String
 
@@ -21,4 +20,4 @@ tests = suite "PointMutations Test Suite"
   ]
 
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/RNATranscription/RNATranscription.elm
+++ b/RNATranscription/RNATranscription.elm
@@ -1,0 +1,6 @@
+module RNATranscription where
+import String
+
+toRNA : String -> String
+toRNA input =
+  ""

--- a/RNATranscription/RNATranscriptionTest.elm
+++ b/RNATranscription/RNATranscriptionTest.elm
@@ -1,12 +1,11 @@
 module RNATranscriptionTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
-import RNATranscriptionExample exposing (toRNA)
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
+
+-- import RNATranscriptionExample exposing (toRNA) -- CI_ENABLE
+import RNATranscription exposing (toRNA) -- CI_DISABLE
 
 tests : Test
 tests = suite "RNATranscription Test Suite"
@@ -17,4 +16,4 @@ tests = suite "RNATranscription Test Suite"
           test "transcribes all ACGT to UGCA" (assertEqual "UGCACCAGAAUU" (toRNA "ACGTGGTCTTAA"))
         ]
 
--- main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/RNATranscription/RNATranscriptionTest.elm
+++ b/RNATranscription/RNATranscriptionTest.elm
@@ -17,4 +17,4 @@ tests = suite "RNATranscription Test Suite"
           test "transcribes all ACGT to UGCA" (assertEqual "UGCACCAGAAUU" (toRNA "ACGTGGTCTTAA"))
         ]
 
-main = runDisplay tests
+-- main = runDisplay tests

--- a/SpaceAge/SpaceAge.elm
+++ b/SpaceAge/SpaceAge.elm
@@ -1,0 +1,9 @@
+module SpaceAge where
+
+ageOn : Planet -> Float -> Float
+ageOn planet seconds =
+  0.0
+
+secondsPerYear : Planet -> Float
+secondsPerYear planet =
+  0.0

--- a/SpaceAge/SpaceAgeTest.elm
+++ b/SpaceAge/SpaceAgeTest.elm
@@ -1,12 +1,11 @@
 module SpaceAgeTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import SpaceAgeExample exposing (Planet(..), ageOn)
+-- import SpaceAgeExample exposing (Planet(..), ageOn) -- CI_ENABLE
+import SpaceAgeExample exposing (Planet(..), ageOn) -- CI_DISABLE
 
 tests : Test
 tests = suite "SpaceAge Test Suite"
@@ -22,4 +21,4 @@ tests = suite "SpaceAge Test Suite"
   ]
 
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Strain/Strain.elm
+++ b/Strain/Strain.elm
@@ -1,0 +1,11 @@
+module Strain where
+
+import List
+
+keep : (a -> Bool) -> List a ->  List a
+keep predicate list =
+  []
+
+discard : (a -> Bool) -> List a -> List a
+discard predicate list =
+  []

--- a/Strain/StrainTest.elm
+++ b/Strain/StrainTest.elm
@@ -1,12 +1,11 @@
 module StrainTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import StrainExample exposing (keep, discard)
+-- import StrainExample exposing (keep, discard) -- CI_ENABLE
+import Strain exposing (keep, discard) -- CI_DISABLE
 
 import String
 
@@ -31,4 +30,4 @@ tests = suite "Strain Test Suite"
     test "discard strings" (assertEqual ["apple", "banana", "cherimoya"] (discard (isFirstLetter "z") ["apple", "zebra", "banana", "zombies", "cherimoya", "zealot"]))
   ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/Sublist/Sublist.elm
+++ b/Sublist/Sublist.elm
@@ -1,0 +1,11 @@
+module Sublist where
+import List exposing (..)
+import String
+
+sublist : List a -> List a -> String
+sublist alist blist =
+  ""
+
+inList : List a -> List a -> Bool
+inList alist blist =
+    False

--- a/Sublist/SublistTest.elm
+++ b/Sublist/SublistTest.elm
@@ -1,12 +1,11 @@
 module SublistTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import SublistExample exposing (sublist)
+-- import SublistExample exposing (sublist) -- CI_ENABLE
+import Sublist exposing (sublist) -- CI_DISABLE
 
 tests : Test
 tests = suite "Sublist Test Suite"
@@ -30,4 +29,4 @@ tests = suite "Sublist Test Suite"
     test "recurring values unequal" (assertEqual "Unequal" (sublist [1,2,1,2,3] [1,2,3,1,2,3,2,3,2,1]))
   ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/SumOfMultiples/SumOfMultiples.elm
+++ b/SumOfMultiples/SumOfMultiples.elm
@@ -1,0 +1,9 @@
+module SumOfMultiples where
+
+sumOfMultiples : List Int -> Int -> Int
+sumOfMultiples factors upperLimit =
+  0
+
+isMultipleOfAnyFactor : List Int -> Int -> Bool
+isMultipleOfAnyFactor factors candidate =
+  False

--- a/SumOfMultiples/SumOfMultiplesTest.elm
+++ b/SumOfMultiples/SumOfMultiplesTest.elm
@@ -1,12 +1,11 @@
 module SumOfMultiplesTest where
 
--- TODO - remove example inclusion once Problem sets are ready to go live or CI is set up.
-
 import ElmTest.Test exposing (test, Test, suite)
 import ElmTest.Assertion exposing (assert, assertEqual)
 import ElmTest.Runner.Element exposing (runDisplay)
 
-import SumOfMultiplesExample exposing (sumOfMultiples)
+-- import SumOfMultiplesExample exposing (sumOfMultiples) -- CI_ENABLE
+import SumOfMultiplesExample exposing (sumOfMultiples) -- CI_DISABLE
 
 tests : Test
 tests = suite "Sum Of Multiples Test Suite"
@@ -19,4 +18,4 @@ tests = suite "Sum Of Multiples Test Suite"
 
   ]
 
-main = runDisplay tests
+main = runDisplay tests -- CI_DISABLE

--- a/TestRunner.elm
+++ b/TestRunner.elm
@@ -8,12 +8,32 @@ import ElmTest.Test exposing (..)
 import LeapTest
 import AccumulateTest
 import RNATranscriptionTest
+import SublistTest
+import BobTest
+import SumOfMultiplesTest
+import StrainTest
+import PointMutationsTest
+import SpaceAgeTest
+import AnagramTest
+import NucleotideCountTest
+import PhoneNumberTest
+import GradeSchoolTest
 
 tests : Test
 tests = suite "ExercismTests"
         [ LeapTest.tests
-        , RNATranscriptionTest.tests
         , AccumulateTest.tests
+        , RNATranscriptionTest.tests
+        , SublistTest.tests
+        , BobTest.tests
+        , SumOfMultiplesTest.tests
+        , StrainTest.tests
+        , PointMutationsTest.tests
+        , SpaceAgeTest.tests
+        , AnagramTest.tests
+        , NucleotideCountTest.tests
+        , PhoneNumberTest.tests
+        , GradeSchoolTest.tests
         ]
 
 port requests : Signal Request

--- a/bin/ci-run-tests.sh
+++ b/bin/ci-run-tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+function ci_enable { sed -i '/CI_ENABLE/ s/^[- ]*//' $1; } 
+function ci_disable { sed -i '/CI_DISABLE/ s/^/-- /' $1; } 
+
+for test_file in */*Test.elm; do ci_enable $test_file; ci_disable $test_file; done
+node_modules/.bin/elm-test TestRunner.elm

--- a/config.json
+++ b/config.json
@@ -20,12 +20,12 @@
     "GradeSchool"
   ],
   "ignored": [
+    "bin",
     "elm-stuff",
-    "bin"
+    "node_modules"
   ],
   "deprecated": [
   ],
   "foregone": [
-  ],
-  "node_modules": []
+  ]
 }


### PR DESCRIPTION
Ok - so I got Travis to [build and run the tests](https://travis-ci.org/madsflensted/xelm/builds/86248954). 

And then I realized that you had intended the users to run the tests [via the reactor](https://github.com/justalisteningman/xelm#running-tests), so my approach is maybe not what you were looking for.

And since this is a forked repository, I can't open and issue where we can discuss the setup, so I opened this PR instead.

I haven't done the Haskell exercises, but expect them to be all code and no GUI, so the same will probably be true for all the initial elm exercises. So using the elm-test module to compile and run tests seems like a simpler way for people to get started, without any complexities from installing jsdom, [apparently there can be problems on Windows](https://github.com/deadfoxygrandpa/Elm-Test#testing-from-the-command-line)

On the other hand the easy of feedback from the elm-reactor can also be a nice thing.
